### PR TITLE
Improve the logic to interact with AWS and add some features

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -216,8 +216,8 @@ define TEST_E2E_NODE_HELP_INFO
 #  RUN_UNTIL_FAILURE: If true, pass --untilItFails to ginkgo so tests are run
 #    repeatedly until they fail.  Defaults to false.
 #  REMOTE: If true, run the tests on a remote host.  Defaults to false.
-#  REMOTE_MODE: For REMOTE=true only.  Mode for remote execution (eg. gce, ssh).
-#    If set to "gce", an instance can be provisioned or reused from GCE. If set
+#  REMOTE_MODE: For REMOTE=true only.  Mode for remote execution (eg. gce, aws, ssh).
+#    If set to "gce" or "aws", an instance can be provisioned or reused from GCE/AWS. If set
 #    to "ssh", provided `HOSTS` must be IPs or resolvable.  Defaults to "gce".
 #  ARTIFACTS: Local directory to scp test artifacts into from the remote hosts
 #    for REMOTE=true. Local directory to write juntil xml results into for REMOTE=false.
@@ -258,6 +258,8 @@ define TEST_E2E_NODE_HELP_INFO
 #  SSH_KEY: For REMOTE=true only. Path to SSH key to use.
 #  SSH_OPTIONS: For REMOTE=true only. SSH options to use.
 #  RUNTIME_CONFIG: The runtime configuration for the API server on the node e2e tests.
+#  INSTANCE_PROFILE: For REMOTE=true and running on AWS only. An AWS IAM instance profile to use with the node. 
+#  USER_DATA_FILE: For REMOTE=true and running on AWS only. Userdata file to use when launching an instance.
 #
 # Example:
 #   make test-e2e-node FOCUS=Kubelet SKIP=container

--- a/test/e2e_node/remote/aws_runner.go
+++ b/test/e2e_node/remote/aws_runner.go
@@ -91,7 +91,7 @@ func (a *AWSRunner) Validate() error {
 func (a *AWSRunner) StartTests(suite TestSuite, archivePath string, results chan *TestResult) (numTests int) {
 	for i := range a.internalAWSImages {
 		img := a.internalAWSImages[i]
-		fmt.Printf("Initializing e2e tests using image %s /  %s.\n", img.imageDesc, img.amiID)
+		fmt.Printf("Initializing e2e tests using image %s / %s.\n", img.imageDesc, img.amiID)
 		numTests++
 		go func() {
 			results <- a.testAWSImage(suite, archivePath, img)
@@ -310,6 +310,7 @@ func (a *AWSRunner) getAWSInstance(img internalAWSImage) (*awsInstance, error) {
 
 		// generate a temporary SSH key and send it to the node via instance-connect
 		if *instanceConnect && !createdSSHKey {
+			klog.Info("instance-connect flag is set, using ec2 instance connect to configure a temporary SSH key")
 			err = a.assignNewSSHKey(testInstance)
 			if err != nil {
 				continue


### PR DESCRIPTION
@dims @tzneal This should work nicely now. 

New features:
- Works properly with cloud-init, you can pass a cloud-init file https://github.com/upodroid/test-infra-1/blob/sig-node-aws-ubuntu/jobs/e2e_node/containerd/containerd-main/ubuntu-init.yaml
- ssh-users are configured via args, easy to switch between ubuntu and al2

On sidenote, SIG Node dont build from public Ubuntu images so I need some help to make the tests go green. I'm happy to introduce them as an optional test.

```
make test-e2e-node REMOTE=true REMOTE_MODE=aws IMAGES="ami-02a6a91c1d29fc428" DELETE_INSTANCES=true SSH_USER=ubuntu CLOUD_INIT_FILE=~/k8s-test-infra/jobs/e2e_node/containerd/containerd-main/ubuntu-init.yaml
```

Yields a test run that looks like this:

```
Summarizing 24 Failures:
  [FAIL] [sig-network] Networking Granular Checks: Pods [It] should function for node-pod communication: http [LinuxOnly] [NodeConformance] [Conformance]
  test/e2e/framework/network/utils.go:733
  [FAIL] [sig-node] Pods [It] should support retrieving logs from the container over websockets [NodeConformance] [Conformance]
  test/e2e/framework/pod/pod_client.go:106
  [FAIL] [sig-node] Security Context When creating a pod with HostUsers [It] must create the user namespace if set to false [LinuxOnly] [Feature:UserNamespacesStatelessPodsSupport]
  test/e2e/common/node/security_context.go:106
  [FAIL] [sig-node] Security Context when creating a pod in the host IPC namespace [It] should show the shared memory ID in the host IPC containers [NodeFeature:HostAccess]
  test/e2e/framework/pod/pod_client.go:238
  [FAIL] [sig-storage] Projected downwardAPI [It] should set mode on item file [LinuxOnly] [NodeConformance] [Conformance]
  test/e2e/framework/pod/output/output.go:238
  [FAIL] [sig-node] Security Context when creating containers with AllowPrivilegeEscalation [It] should allow privilege escalation when not explicitly set and uid != 0 [LinuxOnly] [NodeConformance]
  test/e2e/framework/pod/pod_client.go:238
  [FAIL] [sig-node] Security Context When creating a container with runAsNonRoot [It] should run with an image specified user ID
  test/e2e/framework/pod/pod_client.go:238
  [FAIL] [sig-node] Summary API [NodeConformance] when querying /stats/summary [It] should report resource usage through the stats api
  test/e2e_node/summary_test.go:332
  [FAIL] [sig-node] Pods [It] should patch a pod status [Conformance]
  test/e2e/common/node/pods.go:1108
  [FAIL] [sig-network] Networking Granular Checks: Pods [It] should function for intra-pod communication: http [NodeConformance] [Conformance]
  test/e2e/framework/network/utils.go:733
  [FAIL] [sig-node] ContainerLogPath [NodeConformance] Pod with a container printed log to stdout [BeforeEach] should print log to correct log path
  test/e2e_node/log_path_test.go:123
  [FAIL] [sig-node] Security Context when creating containers with AllowPrivilegeEscalation [It] should allow privilege escalation when true [LinuxOnly] [NodeConformance]
  test/e2e/framework/pod/pod_client.go:238
  [FAIL] [sig-node] ResourceMetricsAPI [NodeFeature:ResourceMetrics] when querying /resource/metrics [It] should report resource usage through the resource metrics api
  test/e2e_node/resource_metrics_test.go:111
  [FAIL] [sig-node] Variable Expansion [It] should allow substituting values in a container's args [NodeConformance] [Conformance]
  test/e2e/framework/pod/output/output.go:238
  [FAIL] [sig-node] Kubelet when scheduling a busybox command that always fails in a pod [It] should have an terminated reason [NodeConformance] [Conformance]
  test/e2e/common/node/kubelet.go:127
  [FAIL] [sig-node] Pods [It] should delete a collection of pods [Conformance]
  test/e2e/common/node/pods.go:877
  [FAIL] [sig-node] ImageCredentialProvider [Feature:KubeletCredentialProviders] [It] should be able to create pod with image credentials fetched from external credential provider 
  test/e2e/framework/pod/pod_client.go:106
  [FAIL] [sig-node] Security Context when creating containers with AllowPrivilegeEscalation [It] should not allow privilege escalation when false [LinuxOnly] [NodeConformance] [Conformance]
  test/e2e/framework/pod/pod_client.go:238
  [FAIL] [sig-node] ImageID [NodeFeature: ImageID] [It] should be set to the manifest digest (from RepoDigests) when available
  test/e2e_node/image_id_test.go:57
  [FAIL] [sig-node] Pods [It] should run through the lifecycle of Pods and PodStatus [Conformance]
  test/e2e/common/node/pods.go:959
  [FAIL] [sig-node] Kubelet when scheduling a read only busybox container [It] should not write to root filesystem [LinuxOnly] [NodeConformance] [Conformance]
  test/e2e/framework/pod/pod_client.go:106
  [FAIL] [sig-storage] Secrets [It] optional updates should be reflected in volume [NodeConformance] [Conformance]
  test/e2e/framework/pod/pod_client.go:106
  [FAIL] [sig-storage] Downward API volume [It] should set mode on item file [LinuxOnly] [NodeConformance] [Conformance]
  test/e2e/framework/pod/output/output.go:238
  [FAIL] [sig-node] Security Context when creating a pod in the host IPC namespace [It] should not show the shared memory ID in the non-hostIPC containers [NodeFeature:HostAccess]
  test/e2e/framework/pod/pod_client.go:238

Ran 261 of 390 Specs in 1263.240 seconds
FAIL! -- 237 Passed | 24 Failed | 0 Pending | 129 Skipped


Ginkgo ran 1 suite in 21m3.454241619s

Test Suite Failed
You're using deprecated Ginkgo functionality:
=============================================
  --untilItFails is deprecated, use --until-it-fails instead
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#changed-command-line-flags

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.7.0


Failure Finished Test Suite on Host i-0d4241fd89a74afc5
command [ssh -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o CheckHostIP=no -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o LogLevel=ERROR -i /tmp/.ssh-key-1409046215 ubuntu@3.10.212.17 -- sudo sh -c 'cd /tmp/node-e2e-20230225T191633 && timeout -k 30s 2700.000000s ./ginkgo -timeout=24h -nodes=8  -skip="\[Flaky\]|\[Slow\]|\[Serial\]"  -untilItFails=false  ./e2e_node.test -- --system-spec-name= --system-spec-file= --extra-envs= --runtime-config= --v 4 --node-name=i-0d4241fd89a74afc5 --report-dir=/tmp/node-e2e-20230225T191633/results --report-prefix=shortname --image-description="imagedesc" --kubelet-flags=--kernel-memcg-notification=true --kubelet-flags=--feature-gates=DisableKubeletCloudCredentialProviders=true,KubeletCredentialProviders=true --kubelet-flags=--image-credential-provider-config=/tmp/node-e2e-20230225T191633/credential-provider.yaml --kubelet-flags=--image-credential-provider-bin-dir=/tmp/node-e2e-20230225T191633 --kubelet-flags="--cluster-domain=cluster.local" --dns-domain="cluster.local" --container-runtime-endpoint=unix:///run/containerd/containerd.sock '] failed with error: exit status 1
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
<                              FINISH TEST                               <
<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

```


Current e2e tests run on `ubuntu-gke-2204` and `cos-cloud` images which makes life hard.

```
W0225 16:26:29.174] I0225 16:26:29.128211    7432 run_remote.go:597] Creating instance {image:ubuntu-gke-2204-1-25-v20230222 imageDesc:ubuntu-gke-2204-1-25-v20230222 kernelArguments:[] project:ubuntu-os-gke-cloud resources:{Accelerators:[]} metadata:0xc00082e230 machine:n1-standard-2 tests:[]} with service account "392769659984-compute@developer.gserviceaccount.com"
W0225 16:26:29.185] I0225 16:26:29.166484    7432 run_remote.go:597] Creating instance {image:cos-stable-101-17162-127-8 imageDesc:cos-stable-101-17162-127-8 kernelArguments:[] project:cos-cloud resources:{Accelerators:[]} metadata:0xc00082e150 machine:n1-standard-2 tests:[]} with service account "392769659984-compute@developer.gserviceaccount.com"
W0225 16:26:29.185] I0225 16:26:29.185531    7432 run_remote.go:597] Creating instance {image:cos-stable-101-17162-127-8 imageDesc:cos-stable-101-17162-127-8 kernelArguments:[] project:cos-cloud resources:{Accelerators:[{Type:nvidia-tesla-k80 Count:2}]} metadata:0xc0003e9a40 machine:n1-standard-2 tests:[]} with service account "392769659984-compute@developer.gserviceaccount.com"
```